### PR TITLE
fixed bug of missing braces in 'if' blocks

### DIFF
--- a/libparmetis/gkmpi.c
+++ b/libparmetis/gkmpi.c
@@ -192,9 +192,10 @@ int gkMPI_Alltoallv(void *sendbuf, idx_t *sendcounts,
   /* bail-out if MPI 3.x cannot handle such large counts */
   for (i=0; i<npes; i++) { 
     if (sendcounts[i] >= INT_MAX || sdispls[i] >= INT_MAX || 
-        recvcounts[i] >= INT_MAX || rdispls[i] >= INT_MAX)
+        recvcounts[i] >= INT_MAX || rdispls[i] >= INT_MAX) {
       errexit("MPI_Gatherv message sizes goes over INT_MAX. Use MPI 4.x\n");
       break;
+    }
   }
     
   lsendcounts = gk_imalloc(npes, "lsendcounts");
@@ -250,9 +251,10 @@ int gkMPI_Allgatherv(void *sendbuf, idx_t sendcount, MPI_Datatype sendtype,
 
   /* bail-out if MPI 3.x cannot handle such large counts */
   for (i=0; i<npes; i++) { 
-    if (sendcount >= INT_MAX || recvcounts[i] >= INT_MAX || rdispls[i] >= INT_MAX)
+    if (sendcount >= INT_MAX || recvcounts[i] >= INT_MAX || rdispls[i] >= INT_MAX) {
       errexit("MPI_Allgatherv message sizes goes over INT_MAX. Use MPI 4.x\n");
       break;
+    }
   }
 
   lrecvcounts = gk_imalloc(npes, "lrecvcounts");
@@ -302,9 +304,10 @@ int gkMPI_Scatterv(void *sendbuf, idx_t *sendcounts, idx_t *sdispls,
 
   /* bail-out if MPI 3.x cannot handle such large counts */
   for (i=0; i<npes; i++) { 
-    if (sendcounts >= INT_MAX || recvcount >= INT_MAX || sdispls[i] >= INT_MAX)
+    if (sendcounts[i] >= INT_MAX || recvcount >= INT_MAX || sdispls[i] >= INT_MAX) {
       errexit("MPI_Scatterv message sizes goes over INT_MAX. Use MPI 4.x\n");
       break;
+    }
   }
 
   lsendcounts = gk_imalloc(npes, "lsendcounts");
@@ -354,9 +357,10 @@ int gkMPI_Gatherv(void *sendbuf, idx_t sendcount, MPI_Datatype sendtype,
 
   /* bail-out if MPI 3.x cannot handle such large counts */
   for (i=0; i<npes; i++) { 
-    if (sendcount >= INT_MAX || recvcounts[i] >= INT_MAX || rdispls[i] >= INT_MAX)
+    if (sendcount >= INT_MAX || recvcounts[i] >= INT_MAX || rdispls[i] >= INT_MAX) {
       errexit("MPI_Gatherv message sizes goes over INT_MAX. Use MPI 4.x\n");
       break;
+    }
   }
 
 


### PR DESCRIPTION
In libparmetis/gkmpi.c there are a few "if" blocks that are missing braces and the file fails to compile (GNU Fortran (GCC) 10.3.1 20210422).
Also in line 307 of the same file the line:
if (sendcounts >= INT_MAX || recvcount >= INT_MAX || sdispls[i] >= INT_MAX)
should be modified to:
if (sendcounts[i] >= INT_MAX || recvcount >= INT_MAX || sdispls[i] >= INT_MAX)
