### PR TITLE
Fix MSVC thread-local storage probe

### DIFF
--- a/conf/check_thread_storage.c
+++ b/conf/check_thread_storage.c
@@ -1,5 +1,9 @@
-extern __thread int x;
+#if defined(_MSC_VER)
+#define __thread __declspec(thread)
+#endif
+
+__thread int x;
 
 int main(int argc, char **argv) {
-  return 0;
+  return x;
 }


### PR DESCRIPTION
The MSVC TLS probe currently compiles `extern __thread int x;` without the `__thread=__declspec(thread)` definition accumulated in `GK_COPTIONS`. The probe fails with C2054/C2085, so `conf/gkbuild.cmake` appends an empty `-D__thread=` even when the linked GKlib uses real TLS.

Make the probe self-contained for MSVC and define/read a TLS variable so that the test checks actual TLS access instead of an unused declaration. Other compilers retain `__thread`.

The same issue has existing METIS proposals: https://github.com/KarypisLab/METIS/pull/74 and https://github.com/KarypisLab/METIS/pull/114. This PR fixes the matching probe in ParMETIS.

Validation on Windows x64/MSVC with MS-MPI:

- Original probe: `HAVE_THREADLOCALSTORAGE=FALSE`, final flags contain both `-D__thread=__declspec(thread)` and `-D__thread=`.
- Patched probe: `HAVE_THREADLOCALSTORAGE=TRUE`, no empty override.
- Rebuilt vcpkg ParMETIS 2023-03-26 and METIS 2025-07-04 with the same probe fix and unchanged GKlib/MPI dependencies.
- Standalone 40x40 undirected-grid consumer using `ParMETIS_V3_PartKway`: original Release/MPI2 crashes at `METIS_PartGraphKway` -> `setjmp`; patched Debug/Release with MPI2/MPI4 pass. A repeated-call regression also verifies every partition ID, nonempty coverage, and the reported edge cut against the gathered partition.

The runtime crash is specifically caused by METIS reading GKlib TLS signal buffers as ordinary globals. Both projects contain the defective detection; this change makes ParMETIS agree with GKlib as well. No partitioning algorithm changes. Non-Windows builds were not run.
